### PR TITLE
Less verbose and more clear API key section. Fixes #2.

### DIFF
--- a/js/wp101.js
+++ b/js/wp101.js
@@ -28,5 +28,9 @@
 			});
 			$(this).parents('li').remove();
 		});
+		$('a#show-wp101-api-key').click(function(){
+			$(this).remove();
+			$('#wp101-api-key').css('visibility', 'visible');
+		});
 	});
 })(jQuery);


### PR DESCRIPTION
- Headed under "API Key".
- Only explains the API key concept if you don't have a valid key.
- Switch to using a text input instead of password.
- Hide valid API keys behind a link (for "peeking over someone's shoulder" protection).
- Show the API key message in an "update" callout box.
- Use the options-general settings icon (should replace with a full size wp101 icon!).
- Normal h2 formatting to blend in better with WordPress.

Fixes #2.
