### PR TITLE
Pass custom User Agent to get around WP Engine's strict caching.

### DIFF
--- a/wp101.php
+++ b/wp101.php
@@ -50,7 +50,7 @@ class WP101_Plugin {
 	private function validate_api_key_with_server( $key=NULL ) {
 		if ( NULL === $key )
 			$key = $this->get_key();
-			$query = wp_remote_get( self::$api_base . 'action=check_key&api_key=' . $key, array( 'timeout' => 45, 'sslverify' => false ) );
+		$query = wp_remote_get( self::$api_base . 'action=check_key&api_key=' . $key, array( 'timeout' => 45, 'sslverify' => false, 'user-agent' => 'WP101Plugin' ) );
 
 		if ( is_wp_error( $query ) )
 			return false; // Failed to query the server
@@ -211,7 +211,7 @@ class WP101_Plugin {
 			if ( $topics = get_transient( 'wp101_topics' ) ) {
 				return $topics;
 			} else {
-				$result = wp_remote_get( self::$api_base . 'action=get_topics&api_key=' . $this->get_key() );
+				$result = wp_remote_get( self::$api_base . 'action=get_topics&api_key=' . $this->get_key(), array( 'timeout' => 45, 'sslverify' => false, 'user-agent' => 'WP101Plugin' ) );
 				$result = json_decode( $result['body'], true );
 				if ( !$result['error'] && count( $result['data'] ) ) {
 					set_transient( 'wp101_topics', $result['data'], 24*3600 ); // Good for a day.


### PR DESCRIPTION
WP Engine appears to have very strict User Agent-based caching rules. It seems that when caching is triggered, all URL parameters are stripped. Thus WP101Plugin API requests just get served a cached view of the wp101plugin.com web site. Passing in a User Agent of "WP101Plugin" seems to get around this.

fixes #11
