### PR TITLE
Add WP101_API_KEY

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WP101 ===
-Contributors: shawndh, markjaquith, mordauk
+Contributors: shawndh, markjaquith, mordauk, wpsmith
 Tags: wp101, tutorials, video, help, learn, screencast
 Requires at least: 3.2
 Tested up to: 3.5.1
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 
 Delivers a complete set of WordPress tutorial videos directly within the dashboard. Choose which videos to show, or add your own!
 
@@ -49,6 +49,9 @@ You can ask your developer to renew their subscription, or you can go to [WP101P
 2. The configuration interface, where you can enter your API key, hide videos from the list, or add your own custom videos!
 
 == Changelog ==
+
+= 2.0.3 =
+* Setup constant WP101_API_KEY for use in wp-config.php
 
 = 2.0.2 =
 * Bug fix to address "API key not valid" error on multisite installations.

--- a/wp101.php
+++ b/wp101.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: WP101
 Description: WordPress tutorial videos, delivered directly to your WordPress admin
-Version: 2.0.2
+Version: 2.0.3
 Author: WP101Plugin.com
 Author URI: http://wp101plugin.com/
 */
@@ -66,6 +66,8 @@ class WP101_Plugin {
 			if ( empty( $db ) && isset( $_wp101_api_key ) && !empty( $_wp101_api_key ) ) {
 				update_option( 'wp101_api_key', $_wp101_api_key );
 				return $_wp101_api_key;
+			} elseif ( empty( $db ) && defined( 'WP101_API_KEY' ) ) {
+				update_option( 'wp101_api_key', WP101_API_KEY );
 			} else {
 				return $db;
 			}


### PR DESCRIPTION
Added WP101_API_KEY for use in wp-config.php. Currently, WP101 allows the key to be hardcoded into the plugin.

``` php
// API KEY
// You can hardcode the API key here, and it will be used as a starting value for the key
$_wp101_api_key = '';
```

However, this is lost on a site update (yet retained in the db). I recommend a switch to using a constant that can be added to wp-config, maintaining backwards compatability. I've added the code for you to check out with proper notations in the change log and readme (again pending your approval).
