### PR TITLE
Issue 27

### DIFF
--- a/wp101.php
+++ b/wp101.php
@@ -580,25 +580,26 @@ class WP101_Plugin {
 			$admins = get_users( $args );
 	?>
 		<h3 class="title"><?php _e( 'Settings Management', 'wp101' ); ?></h3>
-		<p class="description"><?php _e( 'By default, all administrators can change the settings above. Optionally, ', 'wp101' ); ?></p>
+		<p class="description"><?php _e( 'By default, all administrators can change the settings above. Optionally, choose a specific admin who alone will have access to this settings panel.', 'wp101' ); ?></p>
 		<form action="" method="post">
-		<input type="hidden" name="wp101-action" value="admin-restriction" />
+		<input type="hidden" name="wp101-action" value="restrict-admin" />
 		<?php wp_nonce_field( 'wp101-admin_restriction' ); ?>
 		<table class="form-table">
 		<tr valign="top">
 			<th scope="row"><label for="wp101-admin-restriction"><?php _e( 'Settings Access:', 'wp101' ); ?></label></th>
 			<td>
 				<select class="regular-text" type="text" id="wp101-admin-restriction" name="wp101_admin_restriction">
-
+					<option value=''><?php _e( 'All Administators', 'wp101' ); ?></option>
+					<?php
+						foreach ( $admins as $admin ) {
+							echo '<option value="' . $admin->ID . '" ' . selected( $admin->ID, get_option( 'wp101_admin_restriction' ), false ) . '>' . esc_html( $admin->display_name ) . '</option>';
+						}
+					?>
 				</select>
 			</td>
 		</tr>
 		</table>
-		<?php if ( 'valid' === $this->validate_api_key() ) : ?>
-			<?php submit_button( __( 'Change API Key', 'wp101' ) ); ?>
-		<?php else : ?>
-			<?php submit_button( __( 'Set API Key', 'wp101' ) ); ?>
-		<?php endif; ?>
+		<?php submit_button(); ?>
 		</form>
 
 	<?php

--- a/wp101.php
+++ b/wp101.php
@@ -89,8 +89,10 @@ class WP101_Plugin {
 	public function update_api_key() {
 
 		check_admin_referer( 'wp101-update_key' );
+
 		$new_key = preg_replace( '#[^a-f0-9]#', '', stripslashes( $_POST['wp101_api_key'] ) );
 		$result = $this->validate_api_key_with_server( $new_key );
+
 		if ( 'valid' == $result ) {
 			update_option( 'wp101_api_key', $new_key );
 			set_transient( 'wp101_message', 'valid', 300 );
@@ -101,6 +103,7 @@ class WP101_Plugin {
 		} else {
 			set_transient( 'wp101_message', 'error', 300 );
 		}
+
 		wp_redirect( admin_url( 'admin.php?page=wp101&configure=1' ) );
 		exit();
 	}


### PR DESCRIPTION
This series of commits fixes #27.  A few notes:

* We've added a series of filters to allow for a couple helpful scenarios:
    * `wp101_is_user_authorized` - allows a developer to override the authorization routine.  A great use case would be if someone's client has their user set to be the only admin, but the developer also needs to access the settings. Filtering this conditionally would allow for a whitelist of sorts.
    * `wp101_default_settings_role` - When counting admins, we default to counting the administrators. This filter can be used in conjunction with the `wp101_settings_management_user_args` filter to change the actual role that we're allowing for.  A good example might be a site that actually has no administrator roles, but a custom role, like a store manager or something. 
    * `wp101_too_many_admins` - This provides a sane default for what we consider to be too many admins for this UX.  Drop-downs are pretty crappy when you're dealing with a bunch of options, so we have a super high limit of 100.  This can be changed to whatever one desires.
    * `wp101_settings_management_user_args` - Used in conjunction with `wp101_default_settings_role`, this filters the array of arguments passed to `get_users()` to populate the drop-down.

Tested, of course, but could always use more testing!