### PR TITLE
Return the ‘plugin_action_links_’ filter argument in all cases

### DIFF
--- a/wp101.php
+++ b/wp101.php
@@ -65,8 +65,8 @@ class WP101_Plugin {
 	        $url = get_admin_url() . 'admin.php?page=wp101&configure=1';
 	        $settings_link = '<a href="'.$url.'">' . __( 'Settings', 'wp101' ) . '</a>';
 	        array_unshift( $links, $settings_link );
-	        return $links;
 	    }
+	    return $links;
 	}
 
 	public function get_api_base() {


### PR DESCRIPTION
Previously it was only returned if the authorization check succeeded, causing errors in some edge-cases