### PR TITLE
Prevent error message upon key migration

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -70,6 +70,7 @@ function get_addon_capability() {
  * Register the WP101 settings page.
  */
 function register_menu_pages() {
+	Migrate\maybe_migrate();
 
 	// If we can't retrieve a playlist, *only* show the settings page.
 	$playlist = TemplateTags\api()->get_playlist();
@@ -206,8 +207,6 @@ function sanitize_api_key( $key ) {
  * Render the WP101 add-ons page.
  */
 function render_addons_page() {
-	Migrate\maybe_migrate();
-
 	$api       = TemplateTags\api();
 	$addons    = $api->get_addons();
 	$purchased = wp_list_pluck( $api->get_playlist()['series'], 'slug' );
@@ -219,8 +218,6 @@ function render_addons_page() {
  * Render the WP101 listings page.
  */
 function render_listings_page() {
-	Migrate\maybe_migrate();
-
 	$api        = TemplateTags\api();
 	$playlist   = $api->get_playlist();
 	$public_key = $api->get_public_api_key();
@@ -235,8 +232,6 @@ function render_listings_page() {
  * Render the WP101 settings page.
  */
 function render_settings_page() {
-	Migrate\maybe_migrate();
-
 	include WP101_VIEWS . '/settings.php';
 }
 

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -65,7 +65,7 @@ function maybe_migrate() {
  * @return bool Whether or not the API key needs exchanged.
  */
 function api_key_needs_migration( $api_key ) {
-	return $api_key && 32 !== strlen( $api_key );
+	return $api_key && 32 !== mb_strlen( $api_key );
 }
 
 /**


### PR DESCRIPTION
On WP101 pages, the `WP101\Migrate\maybe_migrate()` function runs to ensure that legacy API keys have been migrated from WP101 < 5.0.0.

While this works, this also means that requests for playlists — which are done on *every* admin page, in order to determine whether or not we can show the playlist page — will try to request the playlist with the old API key when one is present.

This merge request moves the migration logic into the `admin_menus` hook — before trying to get the playlist, attempt to migrate the key if necessary (this request will automatically return early once a key has been migrated).

Fixes #45.