### PR TITLE
Multisite Migration

### DIFF
--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -24,7 +24,7 @@ function maybe_migrate() {
 	}
 
 	// Schedule additional migrations if this is a multisite network.
-	if ( is_multisite() && ! get_site_option( 'wp101-bulk-migration-lock', false ) ) {
+	if ( is_multisite() && is_super_admin() && ! get_site_option( 'wp101-bulk-migration-lock', false ) ) {
 		if ( ! wp_next_scheduled( 'wp101-bulk-migration' ) ) {
 			wp_schedule_single_event( time(), 'wp101-bulk-migration' );
 		}

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -23,6 +23,15 @@ function maybe_migrate() {
 		return;
 	}
 
+	// Schedule additional migrations if this is a multisite network.
+	if ( is_multisite() && ! get_site_option( 'wp101-bulk-migration-lock', false ) ) {
+		if ( ! wp_next_scheduled( 'wp101-bulk-migration' ) ) {
+			wp_schedule_single_event( time(), 'wp101-bulk-migration' );
+		}
+
+		add_site_option( 'wp101-bulk-migration-lock', true );
+	}
+
 	// Key is either empty or already good to go.
 	if ( ! api_key_needs_migration( $key ) ) {
 		return;

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -283,6 +283,36 @@ class MigrateTest extends TestCase {
 	 * @group multisite
 	 * @ticket https://github.com/leftlane/wp101plugin/issues/47
 	 */
+	public function test_migrate_multisite_will_batch_queries() {
+		$this->skip_if_not_multisite();
+
+		$blog_ids = $this->factory->blog->create_many( 7 );
+
+		foreach ( $blog_ids as $blog_id ) {
+			add_blog_option( $blog_id, 'wp101_api_key', self::LEGACY_API_KEY );
+		}
+
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )
+			->andReturn( [
+				'apiKey' => self::CURRENT_API_KEY,
+			] );
+
+		$this->assertSame( 7, Migrate\migrate_multisite( 3 ) );
+
+		foreach ( $blog_ids as $blog_id ) {
+			$this->assertSame(
+				self::CURRENT_API_KEY,
+				get_blog_option( $blog_id, 'wp101_api_key' ),
+				"The API key should have been updated for blog #{$blog_id}."
+			);
+		}
+	}
+
+	/**
+	 * @group multisite
+	 * @ticket https://github.com/leftlane/wp101plugin/issues/47
+	 */
 	public function test_migrate_multisite_will_remove_lock_if_an_error_occurs() {
 		$this->skip_if_not_multisite();
 

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -69,6 +69,17 @@ class TestCase extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Determine if we're currently running in a WordPress Multisite environment.
+	 *
+	 * @return bool
+	 */
+	protected function skip_if_not_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test will only run under WordPress Multisite.' );
+		}
+	}
+
+	/**
 	 * Return a ReflectionMethod with given protected/private $method accessible.
 	 *
 	 * @param  object|string $class  A class name or instance that contains the given method.

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -69,7 +69,18 @@ class TestCase extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Determine if we're currently running in a WordPress Multisite environment.
+	 * Skip the test if we're running in a WordPress Multisite environment.
+	 *
+	 * @return bool
+	 */
+	protected function skip_if_multisite() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'This test will not run under WordPress Multisite.' );
+		}
+	}
+
+	/**
+	 * Skip the test unless we're running in a WordPress Multisite environment.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
When running `Migrate\maybe_migrate()` on a WordPress Multisite instance, schedule a cron job to migrate all other sites in the network asynchronously.

Once the job has been scheduled, the `wp101-bulk-migration-lock` option will be added to the network level, preventing it from being run again.

Fixes #47.