### PR TITLE
Fix invalid offset error in API response

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -480,6 +480,14 @@ class API {
 
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
+		if ( ! isset( $body['status'] ) || ! isset( $body['data'] ) ) {
+			return new WP_Error(
+				'wp101-api',
+				__( 'The WP101 API request response was invalid.', 'wp101' ),
+				$body['data']
+			);
+		}
+
 		if ( 'fail' === $body['status'] ) {
 			return new WP_Error(
 				'wp101-api',


### PR DESCRIPTION
It is possible for the API request to generate an invalid offset error if the array keys for status or body do not exist.

This fixes it by checking to ensure the keys exist before attempting to use them. It will generate a WP_Error if one or both of the keys are missing in the response.