### PR TITLE
Fix an undefined array key warning when using the "wp101_excluded_topics" filter

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -265,7 +265,7 @@ class API {
 				$response['series'][ $key ]['topics'] = array_filter(
 					$series['topics'],
 					function ( $topic ) use ( $excluded ) {
-						if ( isset( $topic['slug'] ) {
+						if ( isset( $topic['slug'] ) ) {
 							return ! in_array( $topic['slug'], $excluded, true );
 						} else {
 							return ! in_array( $topic['legacy_id'], $excluded, true );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -265,8 +265,11 @@ class API {
 				$response['series'][ $key ]['topics'] = array_filter(
 					$series['topics'],
 					function ( $topic ) use ( $excluded ) {
-						return ! in_array( $topic['slug'], $excluded, true )
-						       && ! in_array( $topic['legacy_id'], $excluded, true );
+						if ( isset( $topic['slug'] ) {
+							return ! in_array( $topic['slug'], $excluded, true );
+						} else {
+							return ! in_array( $topic['legacy_id'], $excluded, true );
+						}
 					}
 				);
 			}


### PR DESCRIPTION
Fixes an undefined array key warning when using the "wp101_excluded_topics" filter, and either the "slug" or "legacy_id" array key is not set.

That undefined array key warning is fired for each topic added with that filter. For example, the following code will trigger four warnings.

```
add_filter( 'wp101_excluded_topics', function ( $topics ) {

	$topics[] = 'classic-manage-widgets';
	$topics[] = 'classic-custom-menus';
	$topics[] = 'create-pages';
	$topics[] = 'custom-menus';

	return $topics;

} );
```